### PR TITLE
Remove all redundant constructor definitions.

### DIFF
--- a/jsforwp-blocks/blocks/examples/07-inspector-controls-colors/controls.js
+++ b/jsforwp-blocks/blocks/examples/07-inspector-controls-colors/controls.js
@@ -25,9 +25,6 @@ const {
  */
 export default class Inspector extends Component {
 
-  constructor( props ) {
-    super( ...arguments );
-  }
   render() {
     return (
       <BlockControls key="controls">

--- a/jsforwp-blocks/blocks/examples/07-inspector-controls-colors/inspector.js
+++ b/jsforwp-blocks/blocks/examples/07-inspector-controls-colors/inspector.js
@@ -22,9 +22,6 @@ const {
  */
 export default class Inspector extends Component {
 
-  constructor( props ) {
-    super( ...arguments );
-  }
   render() {
     return (
       <InspectorControls key="inspector">

--- a/jsforwp-blocks/blocks/examples/08-input/input.js
+++ b/jsforwp-blocks/blocks/examples/08-input/input.js
@@ -13,9 +13,6 @@ const { Component } = wp.element;
   * Create an input field Component
  */
 export default class Input extends Component {
-  constructor( props ) {
-    super( ...arguments );
-  }
   render() {
     return (
       <p>

--- a/jsforwp-blocks/blocks/examples/09-input-and-textarea/input.js
+++ b/jsforwp-blocks/blocks/examples/09-input-and-textarea/input.js
@@ -13,9 +13,6 @@ const { Component } = wp.element;
   * Create an input field Component
  */
 export default class Input extends Component {
-  constructor( props ) {
-    super( ...arguments );
-  }
   render() {
     return [
       <label

--- a/jsforwp-blocks/blocks/examples/09-input-and-textarea/textarea.js
+++ b/jsforwp-blocks/blocks/examples/09-input-and-textarea/textarea.js
@@ -13,9 +13,6 @@ const { Component } = wp.element;
   * Create a textarea field Component
  */
 export default class Textarea extends Component {
-  constructor() {
-    super( ...arguments );
-  }
   render() {
     return [
       <label


### PR DESCRIPTION
Hey Zac,

I took the liberty to remove all of your constructor definitions that didn't do anything else than passing on the `...arguments`.

When using inheritance, it takes care that the respective class **inherits** all the methods from its parent, unless you define one of these methods on your own, of course.

So, there is no use in having code like this:

```js
class Foo extends Bar {
    constructor() {
        super( ...arguments );
    }
}
```

as it is equivalent to just this:

```js
class Foo extends Bar {}
```

Cheers,
Thorsten
  