### PR TITLE
Fix CSS emitting to the correct directory

### DIFF
--- a/jsforwp-blocks/webpack.config.js
+++ b/jsforwp-blocks/webpack.config.js
@@ -5,10 +5,10 @@ const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 
 // Set different CSS extraction for editor only and common block styles
 const blocksCSSPlugin = new ExtractTextPlugin( {
-  filename: '../css/blocks.style.css',
+  filename: './assets/css/blocks.style.css',
 } );
 const editBlocksCSSPlugin = new ExtractTextPlugin( {
-  filename: '../css/blocks.editor.css',
+  filename: './assets/css/blocks.editor.css',
 } );
 
 // Configuration for the ExtractTextPlugin.


### PR DESCRIPTION
On the following lines

https://github.com/zgordon/gutenberg-course/blob/e5fa68af2eb6f5b1480e8361fde9ba18da67e12b/jsforwp-blocks/webpack.config.js#L7-L12

the `filename`s should be `filename: './assets/css/blocks.style.css'`, and `filename: './assets/css/blocks.editor.css'`, otherwise the CSS files are emitted one directory up.