### PR TITLE
No need className='components-toolbar'

### DIFF
--- a/jsforwp-blocks/blocks/examples/05-custom-toolbar/index.js
+++ b/jsforwp-blocks/blocks/examples/05-custom-toolbar/index.js
@@ -67,9 +67,7 @@ export default registerBlockType(
                   		value={ props.attributes.alignment }
                   		onChange={ ( value ) => props.setAttributes( { alignment: value } ) }
                   	/>
-                    <Toolbar
-                      className='components-toolbar'
-                    >
+                    <Toolbar>
                       <Tooltip text={ __( 'High Contrast' )  }>
                         <Button
                           className={ classnames(


### PR DESCRIPTION
no need className='components-toolbar'  because Gutenberg by default setting no need components-toolbar Toolbar component.  if we manually  set className='components-toolbar' . we  will see double classes class="components-toolbar components-toolbar"