### PR TITLE
Wait until plugins have loaded to register render callback

### DIFF
--- a/jsforwp-blocks/jsforwp-blocks.php
+++ b/jsforwp-blocks/jsforwp-blocks.php
@@ -168,7 +168,17 @@ function jsforwp_dynamic_alt_block_render( $attributes ) {
 
 }
 
-// Hook server side rendering into render callback
-register_block_type( 'jsforwp/dynamic-alt', [
-    'render_callback' => 'jsforwp_dynamic_alt_block_render',
-] );
+
+/**
+ * Hook server side rendering into render callback
+ */
+function jsforwp_register_render_callback() {
+
+	register_block_type( 'jsforwp/dynamic-alt', [
+	    'render_callback' => 'jsforwp_dynamic_alt_block_render',
+	] );
+
+}
+
+// Hook render callback function into plugins loaded hook
+add_action( 'plugins_loaded', 'jsforwp_register_render_callback' );


### PR DESCRIPTION
By just dropping `register_block_type()` in the main plugin file, you're assuming that function exists. It works in this case because the plugin name starts with "j", so loads after Gutenberg. If you rename this plugin to something else, like "a-gutenberg-block", you get

> Call to undefined function register_block_type()`.

I don't know if there's a specific hook that should be used, but the earliest the code should run is `plugins_loaded`