### PR TITLE
Add babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "@wordpress/default"
+  ]
+}


### PR DESCRIPTION
This PR tells babel to use the `@wordpress/default` plugin for transpiling, which (amongst other things) tells babel how to transpile jsx.

Resolves #25.