### PR TITLE
Conditionally set watch based on NODE_ENV

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,7 @@ module.exports = {
     path: path.resolve( __dirname ),
     filename: '[name].js',
   },
-  watch: true,
+  watch: 'production' !== process.env.NODE_ENV,
   devtool: 'cheap-eval-source-map',
   module: {
     rules: [


### PR DESCRIPTION
If watch is always set to `true`, `npm run build` will watch for changes just like `dev` does, which is likely not the intended behavior for the developer.