### PR TITLE
Add closing tag to <ul> in $markup

### DIFF
--- a/blocks/12-dynamic/index.php
+++ b/blocks/12-dynamic/index.php
@@ -49,5 +49,5 @@ function render_dynamic_block() {
 		);
 	}
 
-	return "{$markup}<ul>";
+	return "{$markup}</ul>";
 }


### PR DESCRIPTION
I think this is just a small typo where the `<ul>` on line 52 should actually be a closing tag for the `<ul>` inside of the `$markup` variable that was declared on line 41