### PR TITLE
Webpack disable children stats

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,4 +65,7 @@ module.exports = {
     blocksCSSPlugin,
     editBlocksCSSPlugin,
   ],
+  stats: {
+    children: false
+  }
 };


### PR DESCRIPTION
Minor tweak to make build info in console less verbose

**Before**
![Before](https://user-images.githubusercontent.com/1039236/46369249-04a83680-c6a0-11e8-9d48-91b8c226cf7b.png)

**After**
![After](https://user-images.githubusercontent.com/1039236/46369258-0eca3500-c6a0-11e8-82bf-52c9d77516e7.png)
