### PR TITLE
add wp-editor into wp_enqueue_script

### DIFF
--- a/lib/enqueue-scripts.php
+++ b/lib/enqueue-scripts.php
@@ -15,7 +15,7 @@ function enqueue_block_editor_assets() {
 	wp_enqueue_script(
 		'jsforwp-blocks-js',
 		_get_plugin_url() . $block_path,
-		[ 'wp-i18n', 'wp-element', 'wp-blocks', 'wp-components' ],
+		[ 'wp-i18n', 'wp-element', 'wp-editor', 'wp-blocks', 'wp-components' ],
 		filemtime( _get_plugin_directory() . $block_path )
 	);
 


### PR DESCRIPTION
In the last update, wp-editor appeared as undefined because it was not added in the dependencies of wp_enqueue_script