### PR TITLE
Update index.js

### DIFF
--- a/blocks/11-url-input/index.js
+++ b/blocks/11-url-input/index.js
@@ -13,7 +13,7 @@ const {
     registerBlockType,
 } = wp.blocks;
 const {
-    UrlInput,
+    URLInput,
 } = wp.editor;
 const {
     IconButton,
@@ -74,7 +74,7 @@ export default registerBlockType(
                                 <Tooltip text="Add Link">
                                     {icon}
                                 </Tooltip>
-                                <UrlInput
+                                <URLInput
                                     className="url"
                                     value={ url }
                                     onChange={ url => setAttributes( { url } ) }


### PR DESCRIPTION
The wp.editor.UrlInput component has been renamed to wp.editor.URLInput, as mentioned here: https://wordpress.org/gutenberg/handbook/reference/deprecated/
Old notation breaks the block when used with Gutenberg 4.5.1