### PR TITLE
Replaced withAPIData with withSelect in comment

### DIFF
--- a/blocks/12-dynamic/index.js
+++ b/blocks/12-dynamic/index.js
@@ -51,7 +51,7 @@ registerBlockType(
                         }) }
                     </ul>
                 );
-            } ) // end withAPIData
+            } ) // end withSelect
         , // end edit
         save() {
             // Rendering in PHP


### PR DESCRIPTION
`withAPIData` has been replaced with `withSelect` in https://github.com/zgordon/gutenberg-course/commit/c19a230ee4c0777fe8f0dedd59f97fb4d8c752a3#diff-710e3d37c8563bc1a3e2b3948c80d1aaR25 but the comment on the closing parenthesis still mentions `withAPIData`.

This PR fixes this.