### PR TITLE
Rename export default from Inspector to Controls

### DIFF
--- a/blocks/07-inspector-control-fields/controls.js
+++ b/blocks/07-inspector-control-fields/controls.js
@@ -13,7 +13,7 @@ const {
 /**
  * Create a Block Controls wrapper Component
  */
-export default class Inspector extends Component {
+export default class Controls extends Component {
 
     constructor() {
         super( ...arguments );


### PR DESCRIPTION
I think this is a typo on the class name. It doesn't matter much in functionality as the class already used as the default export, but it mismatched in context.